### PR TITLE
Created at date not displayed correctly in Full Recipe view

### DIFF
--- a/src/components/RecipeFullView.jsx
+++ b/src/components/RecipeFullView.jsx
@@ -102,7 +102,7 @@ const RecipeFullView = () => {
               loading="lazy"
             />
           </Grid>
-          <Grid item>
+          <Grid item xs={12}>
             <Typography
               gutterBottom
               variant="body1"
@@ -111,7 +111,7 @@ const RecipeFullView = () => {
               {recipe.instructions}
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid item xs={12}>
             <Typography
               data-cy="recipe-created_at"
               variant="caption"


### PR DESCRIPTION
### This PR contains:
- Fix created at date to be displayed on a new line in Full Recipe view

[Pivotal Tracker Chore](https://www.pivotaltracker.com/story/show/181272132)

Before:
![Screenshot from 2022-02-15 20-27-02](https://user-images.githubusercontent.com/92155737/154134532-4e52c43a-6b19-4859-a4d5-97e3d17a77f4.png)

After:
![Screenshot from 2022-02-15 20-23-56](https://user-images.githubusercontent.com/92155737/154134437-aa4b1332-2b00-4372-8b2d-b20d76c37511.png)
