### PR TITLE
Error messages are not shown in Recipe create/update views

### DIFF
--- a/cypress/fixtures/createRecipeNoImageResponse.json
+++ b/cypress/fixtures/createRecipeNoImageResponse.json
@@ -1,0 +1,3 @@
+{
+  "message": "A recipe must have an image"
+}

--- a/cypress/integration/loggedInUserCanCreateARecipe.feature.js
+++ b/cypress/integration/loggedInUserCanCreateARecipe.feature.js
@@ -78,6 +78,7 @@ describe("Recipe", () => {
         fixture: "myRecipesResponse.json"
       });
       cy.intercept("POST", "api/recipes", {
+        statusCode: 422,
         fixture: "createWithoutName.json"
       });
       cy.intercept("GET", "api/ingredients", { body: { ingredients: [] } });
@@ -93,6 +94,33 @@ describe("Recipe", () => {
       cy.get("[data-cy=flash-message]").should(
         "contain",
         "Name can't be blank"
+      );
+    });
+  });
+
+  describe("can't be created without an image", () => {
+    before(() => {
+      cy.intercept("GET", "api/recipes*", {
+        fixture: "myRecipesResponse"
+      });
+      cy.intercept("POST", "api/recipes", {
+        statusCode: 422,
+        fixture: "createRecipeNoImageResponse"
+      });
+      cy.intercept("GET", "api/ingredients", { body: { ingredients: [] } });
+      cy.intercept("GET", "api/recipes", { body: { recipes: [] } });
+      cy.visitAndAuthenticate();
+      cy.get("[data-cy=my-recipes]").click();
+      cy.get("[data-cy=create-recipe]").click();
+      cy.get("[data-cy=recipe-name]").type("Pancakes");
+      cy.get("[data-cy=instructions]").type("Mix them together. Bake");
+      cy.get("[data-cy=submit-btn]").click();
+    });
+
+    it("is expected to see error message", () => {
+      cy.get("[data-cy=flash-message]").should(
+        "contain",
+        "A recipe must have an image"
       );
     });
   });

--- a/src/components/MyRecipes.jsx
+++ b/src/components/MyRecipes.jsx
@@ -12,7 +12,6 @@ const MyRecipes = () => {
 
   const fetchRecipes = async () => {
     const response = await Recipes.index(currentUser);
-
     setRecipes(response.recipes);
   };
 

--- a/src/components/RecipeCreateForm.jsx
+++ b/src/components/RecipeCreateForm.jsx
@@ -27,6 +27,7 @@ const RecipeCreateForm = () => {
     const params = { ...recipe, ingredients_attributes: inputList };
     const response = await Recipes.create(params);
     setMessage(response.message);
+    setTimeout(() => { setMessage("") }, 4000);
   };
 
   const handleChange = (event) => {

--- a/src/components/RecipesMainView.jsx
+++ b/src/components/RecipesMainView.jsx
@@ -9,7 +9,7 @@ const RecipesMainView = () => {
   const fetchRecipes = async () => {
     const response = await Recipes.index();
     if (!response.message) {
-      setRecipes(response);
+      setRecipes(response.recipes);
     }
   };
 

--- a/src/modules/Recipes.js
+++ b/src/modules/Recipes.js
@@ -73,7 +73,7 @@ const Recipes = {
         return data;
       }
     } catch (error) {
-      return error;
+      return error.response?.data || error;
     }
   },
   async update(recipe) {
@@ -95,7 +95,7 @@ const Recipes = {
       );
       return response.data;
     } catch (error) {
-      return error;
+      return error.response?.data || error;
     }
   },
   async getIngredients() {

--- a/src/modules/Recipes.js
+++ b/src/modules/Recipes.js
@@ -12,7 +12,7 @@ const Recipes = {
         return data;
       } else {
         const { data } = await api.get("/recipes");
-        return data.recipes;
+        return data;
       }
     } catch (error) {
       return error;


### PR DESCRIPTION
### This PR contains:
- return error messages from API when getting an error in Recipe create/update methods
- add end2end test to check if user can see error message when trying to create a recipe without an image
- create fixture for Recipe create error response
- set timeout for error message in Recipe create form

@Mljungho @elvitak @DefyCab 

[Pivotal Tracker Chore](https://www.pivotaltracker.com/story/show/181327914)